### PR TITLE
Fix for stack trace on request fail + add feature to optionally skip labels affecting report hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,27 @@
-This is a fork of https://github.com/dvargas46/newman-reporter-allure
+This is a fork of https://github.com/cmttwd/newman-reporter-allure
 
-## Особенности
+## Additions on top of cmttwd's version
+
+Added handling for case where sending request fails and no response is generated.
+Previously reporter would silently exit 'on request' handler and then crash to stack trace in 'on item' attempting to access undefined response_data. Now the report will handle such faults and mark them as broken.
+
+Added support for optional parameters to skip each label to fine-tune needed options:
+--reporter-allure-no-test-class
+--reporter-allure-no-test-method
+--reporter-allure-no-features
+--reporter-allure-no-stories
+--reporter-allure-no-sub-suites
+--reporter-allure-no-test-suite
+This is for if you want all improvements of cmttwd's fork but use more custom suite behaviour.
 
 
-Реализована поддержка Allure TestOps:
-- Добавлены следующие Labels: testClass, testMethod, epic, owner, layer.
-- Изменена логика формирования story и suite.
-
-Отсуттвуют проблемы с формированием русскоязычных имён тестов.
-
-Добавлена обработка test-scripts errors.
-
-Добавлена возможность установки статуса "SKIPPED" через 'pm.test.skip("Skip message")'.
-
-## Установка
+## Installation
 
 ```bash
-$ npm install -g https://github.com/cmttwd/newman-reporter-allure.git
+$ npm install -g https://github.com/akorov/newman-reporter-allure.git
 ```
 
-## Запуск
+## Run
 
 ```bash
 $ newman run <Collection> -e <Environment> -r allure
@@ -28,20 +30,20 @@ $ newman run <Collection> -e <Environment> -r allure --reporter-allure-export <a
 ```
 
 ```bash
---reporter-allure-export <allure-results-out-dir> - путь результов отчета
---reporter-allure-epic <Epic name> - установка параметра Epic для всех тестов запуска
---reporter-allure-owner <Owner name> - установка Владельца/Ответсвенного для всех тестов запуска
+--reporter-allure-export <allure-results-out-dir> - results
+--reporter-allure-epic <Epic name> - set Epic for all tests in the run
+--reporter-allure-owner <Owner name> - set Owner for all tests
 --reporter-allure-layer <Layer> - доп параметр
 ```
 
-## Генерация отчета
+## Generating report
 
 ```bash
 $ allure generate --clean
 $ allure generate --clean <allure-results-out-dir>
 ```
 
-## Открытие сгенерированного отчета
+## Viewing report
 ```bash
 $ allure open
 $ allure open <allure-report-dir>

--- a/index.js
+++ b/index.js
@@ -99,9 +99,6 @@ class AllureReporter {
     }
 
     request(err, args) {
-        if (err) {
-            return
-        }
         const req = args.request;
         let url = req.url.protocol + "://" + req.url.host.join('.');
         if (req.url.path !== undefined) {
@@ -109,24 +106,43 @@ class AllureReporter {
                 url = url + "/" + req.url.path.join('/');
             }
         }
-        const res = args.response;
-        const resp_stream = res.stream;
-        const resp_body = Buffer.from(resp_stream).toString();
         this.runningItems[this.runningItems.length - 1].pm_item.request_data = {
             url: url,
             method: req.method,
             body: req.body,
             headers: req.headers
         };
-        this.runningItems[this.runningItems.length - 1].pm_item.response_data = {
-            status: res.status,
-            code: res.code,
-            body: resp_body,
-            headers: res.headers,
-            cookies: res.cookies,
-            responseTime: res.responseTime,
-            responseSize: res.responseSize
-        };
+
+        if(err){
+            this.runningItems[this.runningItems.length - 1].pm_item.response_data = {
+                status: err,
+                code: err,
+                body: '',
+                headers: '',
+                cookies: '',
+                responseTime: '',
+                responseSize: ''
+            };
+            this.runningItems[this.runningItems.length - 1].pm_item.passed = false;
+            this.runningItems[this.runningItems.length - 1].pm_item.errors.push(err);
+            
+        } else {
+            const res = args.response;
+            const resp_stream = res.stream;
+            const resp_body = Buffer.from(resp_stream).toString();
+
+            this.runningItems[this.runningItems.length - 1].pm_item.response_data = {
+                status: res.status,
+                code: res.code,
+                body: resp_body,
+                headers: res.headers,
+                cookies: res.cookies,
+                responseTime: res.responseTime,
+                responseSize: res.responseSize
+            };
+        }
+        //console.log("REQUEST_PM_ITEM=" + JSON.stringify(this.runningItems[this.runningItems.length - 1].pm_item,null, 4));
+
     }
 
     startStep(name) {
@@ -226,15 +242,20 @@ class AllureReporter {
 
         fullName = this.getFullName(this.currentNMGroup);
 
+        
         // Labels: testClass
         var testClass = fullName;
-        if (testClass !== undefined) {
+        if (testClass !== undefined 
+            && !(this.reporterOptions.noTestClass === true)
+            ) {
             allure_test.addLabel(LabelName.TEST_CLASS, testClass);
         }
 
         // Labels: testMethod
         var testMethod = args.item.name;
-        if (testMethod !== undefined) {
+        if (testMethod !== undefined
+            && !(this.reporterOptions.noTestMethod === true)
+            ) {
             allure_test.addLabel(LabelName.TEST_METHOD, testMethod);
         }
 
@@ -255,23 +276,29 @@ class AllureReporter {
                 parentSuite = fullName;
             }
         }
-
+        
         // Labels: parentSuite
         // Labels: feature
-        if (parentSuite !== undefined) {
+        if (parentSuite !== undefined
+            && !(this.reporterOptions.noFeatures === true)
+            ) {
             parentSuite = parentSuite.charAt(0).toUpperCase() + parentSuite.slice(1);
             allure_test.addLabel(LabelName.PARENT_SUITE, parentSuite);
             allure_test.addLabel(LabelName.FEATURE, parentSuite);
         }
-
+        
         // Labels: story
-        if (suite !== undefined) {
+        if (suite !== undefined
+            && !(this.reporterOptions.noStories === true)
+            ) {
             suite = suite.charAt(0).toUpperCase() + suite.slice(1);
             allure_test.addLabel(LabelName.STORY, suite);
         }
-
+        
         // Labels: subSuite
-        if (subSuites !== undefined) {
+        if (subSuites !== undefined
+            && !(this.reporterOptions.noSubSuites === true)
+            ) {
             if (subSuites.length > 0) {
                 let captalizedSubSuites = [];
 
@@ -281,7 +308,7 @@ class AllureReporter {
                 allure_test.addLabel(LabelName.SUB_SUITE, captalizedSubSuites.join(" > "));
             }
         }
-
+        
         // Labels: suite
         let path;
         if (args.item.request.url.path !== undefined) {
@@ -289,7 +316,9 @@ class AllureReporter {
                 path = args.item.request.url.path.join('/');
             }
         }
-        if (path !== undefined)
+        if (path !== undefined
+            && !(this.reporterOptions.noTestSuite === true)
+            )
             allure_test.addLabel(LabelName.SUITE, path);
 
 
@@ -507,8 +536,23 @@ class AllureReporter {
             });
 
         } else {
-            this.passTestCase(rItem.allure_test);
+            // if we have pm_item.errors but not pm_item.failedAssertions, fail test case
+            if (rItem.pm_item.errors.length > 0){
+                const err = rItem.pm_item.errors
+                            .filter(e => e != null)
+                            .map(e => e)
+                            .join("\n");
+
+                this.failTestCase(rItem.allure_test, {
+                    name: "Pre-assertions error",
+                    message: err,
+                    skipped: rItem.pm_item.skipped
+                });
+            } else {
+                this.passTestCase(rItem.allure_test);
+            }
         }
+
         this.runningItems.pop();
     }
 


### PR DESCRIPTION
Hi, I've addressed a couple of issues as follows:

1) bugfix - add handling for case where sending request fails and no response is generated.

Previously reporter would silently exit 'on request' handler and then crash to stack trace in 'on item' attempting to access undefined response_data. Now the report will handle such faults and mark them as broken. Easy to reproduce example - making a request that can't resolve DNS and fails with ENOTFOUND, attached is sample postman collection.
[Test.postman_collection.json.zip](https://github.com/cmttwd/newman-reporter-allure/files/9234651/Test.postman_collection.json.zip)

2) enhancement - support optional parameters to skip each label to fine-tune needed options:
--reporter-allure-no-test-class
--reporter-allure-no-test-method
--reporter-allure-no-features
--reporter-allure-no-stories
--reporter-allure-no-sub-suites
--reporter-allure-no-test-suite

Default behavior is unchanged - all labels are applied.


Also as a suggestion since you don't have issues enabled - please consider including LICENSE.md in the repo, this reporter is very good but not a single fork has a proper license file, only mentions ISC in package.json at best.